### PR TITLE
fix: only create a single release PR

### DIFF
--- a/.github/workflows/code-review-title.yaml
+++ b/.github/workflows/code-review-title.yaml
@@ -2,7 +2,7 @@ name: CodeReviewTitles
 
 on:
   pull_request:
-    types: ['opened', 'edited', 'reopened', 'synchronize']
+    types: ['opened', 'edited', 'reopened']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,7 @@ jobs:
           command: github-release
           bump-patch-for-minor-pre-major: true
           bump-minor-pre-major: true
+          separate-pull-requests: false
 
       - uses: actions/checkout@v2
         if: ${{ steps.tag-release.outputs.releases_created }}
@@ -99,3 +100,4 @@ jobs:
           package-name: ${{ matrix.package }}
           monorepo-tags: true
           command: release-pr
+          separate-pull-requests: false


### PR DESCRIPTION
instead of creating separate PRs for each changed project, just make one.