### PR TITLE
fix: migrate config to avoid implicitDependencies

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,6 +1,8 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "plugins": ["@nx-go/nx-go"],
+  "plugins": [
+    "@nx-go/nx-go"
+  ],
   "affected": {
     "defaultBase": "master"
   },
@@ -8,19 +10,16 @@
     "appsDir": "apps",
     "libsDir": "packages"
   },
-  "implicitDependencies": {
-    "package.json": {
-      "dependencies": "*",
-      "devDependencies": "*"
-    },
-    ".eslintrc.json": "*",
-    "go.mod": "*"
-  },
   "tasksRunnerOptions": {
     "default": {
-      "runner": "@nrwl/nx-cloud",
+      "runner": "nx-cloud",
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "e2e"],
+        "cacheableOperations": [
+          "build",
+          "lint",
+          "test",
+          "e2e"
+        ],
         "accessToken": "NmE1NWYzNGUtMjZhZC00NmZmLTkwZjUtM2JmZmY2OWFjZTA5fHJlYWQtd3JpdGU="
       }
     },
@@ -33,7 +32,25 @@
   },
   "targetDefaults": {
     "build": {
-      "dependsOn": ["^build"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ]
     }
+  },
+  "namedInputs": {
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals"
+    ],
+    "sharedGlobals": [
+      "{workspaceRoot}/go.mod"
+    ],
+    "production": [
+      "default"
+    ]
   }
 }


### PR DESCRIPTION
fix this warning: 

> Release > NX Using `implicitDependencies` for global implicit dependencies configuration is no longer supported. Use "namedInputs" instead. You can run "nx repair" to automatically migrate your configuration. For more information about the usage of "namedInputs" see https://nx.dev/deprecated/global-implicit-dependencies#global-implicit-dependencies app-one

from here: 
https://github.com/airtonix/golang-monorepo-template/actions/runs/5891417588/job/15978465159